### PR TITLE
Improve handling projects w/o project steps

### DIFF
--- a/raspberryio/project/models.py
+++ b/raspberryio/project/models.py
@@ -75,13 +75,20 @@ class ProjectStep(Orderable, RichText):
         return user.is_superuser or user.id == self.project.user_id
 
     @property
+    def get_steps_count(self):
+        return self.project.steps.count()
+
+    @property
+    def get_order_display(self):
+        return self._order + 1
+
+    @property
     def order(self):
-        """Exposes the step's _order attribute for use in templates"""
         return self._order
 
     @models.permalink
     def get_absolute_url(self):
-        # FIXME: Change to project_step_detail when implemented
+        # FIXME: Change to project_step_detail if/when implemented
         return ('project-detail', [self.project.slug])
 
     def __unicode__(self):

--- a/raspberryio/project/models.py
+++ b/raspberryio/project/models.py
@@ -3,7 +3,7 @@ from django.db import models
 from mezzanine.core.models import (Displayable, Ownable, Orderable, RichText,
     CONTENT_STATUS_DRAFT, CONTENT_STATUS_PUBLISHED)
 from mezzanine.core.fields import RichTextField
-from mezzanine.utils.models import AdminThumbMixin, upload_to
+from mezzanine.utils.models import AdminThumbMixin
 from mezzanine.utils.timezone import now
 from mezzanine.galleries.models import Gallery
 from mezzanine.blog.models import BlogCategory
@@ -22,8 +22,8 @@ class Project(Displayable, Ownable, AdminThumbMixin):
         upload_to='images/project_featured_video_thumbnails',
         blank=True, null=True, editable=False
     )
-    tldr = models.TextField('Summary',
-        help_text='A brief summary of your project'
+    tldr = RichTextField('Description',
+        help_text='A description of your project as a whole.'
     )
     categories = models.ManyToManyField(BlogCategory, related_name='projects')
     score = models.IntegerField(default=0)

--- a/raspberryio/project/tests/test_models.py
+++ b/raspberryio/project/tests/test_models.py
@@ -75,11 +75,30 @@ class ProjectStepTestCase(ProjectBaseTestCase):
             'Superusers should be able to edit any project step',
         )
 
+    def test_get_steps_count_property(self):
+        self.assertEqual(self.project_step.get_steps_count, 1)
+        self.create_project_step(project=self.project)
+        self.assertEqual(self.project_step.get_steps_count, 2)
+        self.create_project_step()
+        self.assertEqual(self.project_step.get_steps_count, 2,
+            "step count shouldn't change when step is added to a different project"
+        )
+
     def test_order_property(self):
         """Assure the order property provides the _order value"""
         self.assertEqual(self.project_step.order, self.project_step._order)
         project_step2 = self.create_project_step(project=self.project)
         self.assertEqual(project_step2.order, project_step2._order)
+
+    def test_get_order_display(self):
+        """Assure the get_order_display method provides the _order value + 1"""
+        self.assertEqual(
+            self.project_step.get_order_display, self.project_step._order + 1
+        )
+        project_step2 = self.create_project_step(project=self.project)
+        self.assertEqual(
+            project_step2.get_order_display, project_step2._order + 1
+        )
 
     def test_order_number(self):
         """

--- a/raspberryio/project/tests/test_views.py
+++ b/raspberryio/project/tests/test_views.py
@@ -144,7 +144,26 @@ class ProjectCreateEditTestCase(AuthViewMixin, ProjectBaseTestCase):
         form_data = {
             'title': 'new-project',
             'tldr': self.get_random_string(),
-            'categories': [self.create_project_category().id]
+            'categories': [self.create_project_category().id],
+            'save': 'value',
+        }
+        response = self.client.post(self.url, form_data, follow=True)
+        new_project = Project.objects.get(slug='new-project')
+        url, status_code = response.redirect_chain[0]
+        expected_url = reverse(
+            'project-detail', args=[new_project.slug]
+        )
+        self.assertEqual(status_code, 302)
+        self.assertTrue(expected_url in url,
+            "Didn't redirect to {0}, redirected to {1}".format(expected_url, url)
+        )
+
+    def test_create_valid_and_add_steps(self):
+        form_data = {
+            'title': 'new-project',
+            'tldr': self.get_random_string(),
+            'categories': [self.create_project_category().id],
+            'save-add-step': 'value',
         }
         response = self.client.post(self.url, form_data, follow=True)
         new_project = Project.objects.get(slug='new-project')
@@ -172,23 +191,7 @@ class ProjectCreateEditTestCase(AuthViewMixin, ProjectBaseTestCase):
         response = self.client.post(self.get_edit_url(), form_data, follow=True)
         current_project = Project.objects.get(title='current-project')
         url, status_code = response.redirect_chain[0]
-        expected_url = reverse('project-step-create-edit', args=[current_project.slug])
-        self.assertEqual(status_code, 302)
-        self.assertTrue(expected_url in url,
-            "Didn't redirect to {0}, redirected to {1}".format(expected_url, url)
-        )
-
-    def test_edit_valid_form_with_steps(self):
-        # Create a project step, so that redirect goes to project detail view
-        self.create_project_step(project=self.project)
-        form_data = {
-            'title': self.get_random_string(),
-            'tldr': self.get_random_string(),
-            'categories': [self.create_project_category().id]
-        }
-        response = self.client.post(self.get_edit_url(), form_data, follow=True)
-        url, status_code = response.redirect_chain[0]
-        expected_url = reverse('project-detail', args=[self.project.slug])
+        expected_url = reverse('project-detail', args=[current_project.slug])
         self.assertEqual(status_code, 302)
         self.assertTrue(expected_url in url,
             "Didn't redirect to {0}, redirected to {1}".format(expected_url, url)

--- a/raspberryio/project/views.py
+++ b/raspberryio/project/views.py
@@ -48,7 +48,7 @@ def project_create_edit(request, project_slug=None):
     project_form = ProjectForm(request.POST or None, instance=project)
     if project_form.is_valid():
         project_form.save()
-        if not project.steps.exists():
+        if 'save-add-step' in request.POST:
             redirect_args = ('project-step-create-edit', project.slug)
         else:
             redirect_args = (project,)

--- a/raspberryio/templates/project/project_create_edit.html
+++ b/raspberryio/templates/project/project_create_edit.html
@@ -12,7 +12,7 @@
     {% if project.id %}
         {% for step in project.steps.all %}
             <a href="{% url 'project-step-create-edit' project.slug step.order %}">
-                Edit step {{ step.order }}
+                Edit step {{ step.order|add:"1" }}
             </a>
             <br>
         {% endfor %}

--- a/raspberryio/templates/project/project_create_edit.html
+++ b/raspberryio/templates/project/project_create_edit.html
@@ -4,13 +4,10 @@
 {% block main %}
     <form class="project-create-edit-form" action="" method="post" accept-charset="utf-8"> {% csrf_token %}
         {{ project_form.as_p }}
-        <input type="submit" id="submit-project-create-edit"
-            {% if project.id %}
-                value="Save and preview"
-            {% else %}
-                value="Save and add project steps"
+        <input type="submit" id="submit-project-create-edit" name="save" value="Save" />
+            {% if not project.id %}
+                <input type="submit" id="submit-project-create-edit" name="save-add-step" value="Save and add project steps" />
             {% endif %}
-        />
     </form>
     {% if project.id %}
         {% for step in project.steps.all %}

--- a/raspberryio/templates/project/project_step_create_edit.html
+++ b/raspberryio/templates/project/project_step_create_edit.html
@@ -4,9 +4,9 @@
 {% block main %}
     <h3>
         {% if project_step.order != None %}
-            Editing step: {{ project_step.order|add:"1" }} of {{ project.title }}
+            Editing step: {{ project_step.get_order_display }} of {{ project.title }}
         {% else %}
-            Creating project step {{ project.steps.count|add:"1" }} for {{ project.title }}
+            Creating project step {{ project_step.get_steps_count|add:"1" }} for {{ project.title }}
         {% endif %}
     </h3>
     <form class="project-step-create-edit-form" action="" method="post" accept-charset="utf-8"> {% csrf_token %}

--- a/raspberryio/templates/project/project_step_create_edit.html
+++ b/raspberryio/templates/project/project_step_create_edit.html
@@ -4,14 +4,14 @@
 {% block main %}
     <h3>
         {% if project_step.order != None %}
-            Editing step: {{ project_step.order }} of {{ project.title }}
+            Editing step: {{ project_step.order|add:"1" }} of {{ project.title }}
         {% else %}
-            Creating a project step for {{ project.title }}
+            Creating project step {{ project.steps.count|add:"1" }} for {{ project.title }}
         {% endif %}
     </h3>
     <form class="project-step-create-edit-form" action="" method="post" accept-charset="utf-8"> {% csrf_token %}
         {{ project_step_form.as_p }}
-        <input type="submit" name="save" id="submit-project-step-create-edit" value="Save and Preview"/>
+        <input type="submit" name="save" id="submit-project-step-create-edit" value="Save and View"/>
         <input type="submit" name="save-add" id="submit-project-step-create-edit-add-another" value="Save and add another" />
     </form>
 {% endblock %}


### PR DESCRIPTION
N.B. - You'll need to run `django-admin.py migrate project 0001` locally before we merge this in. I removed the second project migration rather than adding one that negates it. This shouldn't be a problem because I don't think project migration 0002 has hit staging.

The changes consist of:
- Added a button that exposes option of saving a new project and previewing it (without adding any steps)
- Made the summary field a "description field" that uses rich text so that projects w/o steps can have more than just plain text
- (unrelated to ticket) - Improved consistency of the step numbers being displayed everywhere. This meant displaying them on the project step create/edit page, and also making sure to add one for display everywhere. (instead of numbering 0..)
