### PR TITLE
Revert wiki to use standard header from rest of site

### DIFF
--- a/raspberryio/templates/wiki/base.html
+++ b/raspberryio/templates/wiki/base.html
@@ -5,48 +5,6 @@
   {% block pagetitle %}{% endblock %}
 {% endblock %}
 
-
-{% block global_nav %}
-  <nav id="global-nav">
-    <div class="container">
-      <a class="brand" href="/">{{ settings.SITE_TITLE }}</a>
-      <div class="right-block">
-        <ul class="nav">
-          {% if user.is_authenticated %}
-            {% include "wiki/plugins/notifications/menubaritem.html" %}
-            <li class="dropdown">
-            <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-              <span class="badge notification-cnt">0</span>
-              My Profile
-              <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-              <li><a href="{% url 'profile-dashboard' %}">Dashboard</a></li>
-              <li><a href="{% url 'profile' user.username %}">View Profile</a></li>
-              <li><a href="{% url 'profile_update' %}">Edit Profile</a></li>
-              <li><a href="{% url 'project-create-edit' %}">Create Project</a></li>
-              <li class="divider"></li>
-              <div class="notification-list">
-                <div class="notification-li-container"></div>
-                <li class="notifications-empty"><a href="#"><em>{% trans "No notifications" %}</em></a></li>
-                <li class="divider"></li>
-                <li><a href="#" onclick="notify_mark_read()">{% trans "Clear notifications list" %}</a></li>
-              </div>
-            </ul>
-          </li>
-          <li><a href="{% url 'logout' %}">Log Out</a></li>
-          {% else %}
-          <li><a href="{% url 'login' %}">Log In</a></li>
-          {% endif %}
-        </ul>
-        <form class="navbar-search">
-          <input type="text" class="search-query" placeholder="Search">
-        </form>
-      </div>
-    </div>
-  </nav>
-{% endblock %}
-
 {% block content %}
   {% block wiki_body %}
 

--- a/raspberryio/templates/wiki/base.html
+++ b/raspberryio/templates/wiki/base.html
@@ -9,14 +9,6 @@
   {% block wiki_body %}
 
     <div class="container" style="margin-top: 60px;">
-      {% if messages %}
-      {% for message in messages %}
-      <div class="alert alert-{{ message.tags }}">
-        <a class="close" data-dismiss="alert" href="#">&times;</a>
-        {{ message }}
-      </div>
-      {% endfor %}
-      {% endif %}
       {% block wiki_breadcrumbs %}{% endblock %}
       {% block wiki_contents %}
       <h1>Bootstrap starter template</h1>

--- a/raspberryio/templates/wiki/includes/article_menu.html
+++ b/raspberryio/templates/wiki/includes/article_menu.html
@@ -1,0 +1,53 @@
+{% load i18n wiki_tags %}{% load url from future %}
+
+{% with selected_tab as selected %}
+
+<li class="pull-right{% if selected == "settings" %} active{% endif %}">
+  {% if not user.is_anonymous %}
+  <a href="{% url 'wiki:settings' article_id=article.id path=urlpath.path %}">
+    <span class="icon-wrench"></span>
+    {% trans "Settings" %}
+  </a>
+  {% endif %}
+</li>
+
+{% for plugin in article_tabs %}
+  <li class="pull-right{% if selected == plugin.slug %} active{% endif %}">
+    <a href="{% url 'wiki:plugin' slug=plugin.slug article_id=article.id path=urlpath.path %}">
+      <span class="{{ plugin.article_tab.1 }}"></span>
+      {{ plugin.article_tab.0 }}
+    </a>
+  </li>
+{% endfor %}
+
+<li class="pull-right{% if selected == "history" %} active{% endif %}">
+  <a href="{% url 'wiki:history' article_id=article.id path=urlpath.path %}">
+    <span class="icon-time"></span>
+    {% trans "Changes" %}
+  </a>
+</li>
+
+{% if article|can_write:user and not article.current_revision.locked %}
+<li class="pull-right{% if selected == "edit" %} active{% endif %}">
+  <a href="{% url 'wiki:edit' article_id=article.id path=urlpath.path %}">
+    <span class="icon-edit"></span>
+    {% trans "Edit" %}
+  </a>
+</li>
+{% else %}
+<li class="pull-right{% if selected == "source" %} active{% endif %}">
+  <a href="{% url 'wiki:source' article_id=article.id path=urlpath.path %}">
+    <span class="icon-lock"></span>
+    {% trans "View Source" %}
+  </a>
+</li>
+{% endif %}
+
+<li class="pull-right{% if selected == "view" %} active{% endif %}">
+  <a href="{% url 'wiki:get' article_id=article.id path=urlpath.path %}">
+    <span class="icon-home"></span>
+    {% trans "View" %}
+  </a>
+</li>
+
+{% endwith %}

--- a/raspberryio/templates/wiki/includes/article_menu.html
+++ b/raspberryio/templates/wiki/includes/article_menu.html
@@ -2,15 +2,6 @@
 
 {% with selected_tab as selected %}
 
-<li class="pull-right{% if selected == "settings" %} active{% endif %}">
-  {% if not user.is_anonymous %}
-  <a href="{% url 'wiki:settings' article_id=article.id path=urlpath.path %}">
-    <span class="icon-wrench"></span>
-    {% trans "Settings" %}
-  </a>
-  {% endif %}
-</li>
-
 {% for plugin in article_tabs %}
   <li class="pull-right{% if selected == plugin.slug %} active{% endif %}">
     <a href="{% url 'wiki:plugin' slug=plugin.slug article_id=article.id path=urlpath.path %}">

--- a/raspberryio/urls.py
+++ b/raspberryio/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.views.generic import RedirectView
 
 from django_notify.urls import get_pattern as get_notify_pattern
 from wiki.urls import get_pattern as get_wiki_pattern
@@ -36,6 +37,7 @@ urlpatterns = patterns('',
 
     # wiki
     url(r'^wiki/notify/', get_notify_pattern()),
+    url(r'^wiki/.*_settings/', RedirectView.as_view(url='/wiki/')),
     url(r'wiki/', get_wiki_pattern()),
     # Mezzanine urls
     url(r'^', include('mezzanine.urls')),


### PR DESCRIPTION
Removing the global_nav block will cause the wiki to use the standard global_nav block in the site-wide base template.

Issue #60 
