### PR TITLE
Search tweaks

### DIFF
--- a/raspberryio/qanda/models.py
+++ b/raspberryio/qanda/models.py
@@ -15,7 +15,7 @@ class Question(Displayable, Ownable):
     question = RichTextField()
 
     def __unicode__(self):
-        return u'Question: {0}'.format(self.title)
+        return unicode(self.title)
 
     @models.permalink
     def get_absolute_url(self):

--- a/raspberryio/search/migrations/0001_initial.py
+++ b/raspberryio/search/migrations/0001_initial.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'LatestArticleRevision'
+        db.create_table('search_latestarticlerevision', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('article_id', self.gf('django.db.models.fields.BigIntegerField')(unique=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=512)),
+            ('content', self.gf('django.db.models.fields.TextField')(blank=True)),
+        ))
+        db.send_create_signal('search', ['LatestArticleRevision'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'LatestArticleRevision'
+        db.delete_table('search_latestarticlerevision')
+
+
+    models = {
+        'search.latestarticlerevision': {
+            'Meta': {'object_name': 'LatestArticleRevision'},
+            'article_id': ('django.db.models.fields.BigIntegerField', [], {'unique': 'True'}),
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '512'})
+        }
+    }
+
+    complete_apps = ['search']

--- a/raspberryio/search/models.py
+++ b/raspberryio/search/models.py
@@ -1,5 +1,4 @@
-
-from django.db import models
+from django.db import models, transaction
 
 from mezzanine.core.managers import SearchableManager
 
@@ -16,5 +15,45 @@ class Searchable(models.Model):
 
     class Meta():
         abstract = True
+
+
+class LatestArticleRevision(models.Model):
+    """
+    Copies the latest revision of a wiki article (wiki.ArticleRevision) when
+    saved in order to create a flat list for searching.
+    """
+
+    article_id = models.BigIntegerField(unique=True)
+    title = models.CharField(max_length=512, null=False, blank=False)
+    content = models.TextField(blank=True)
+
+    search_classname = 'Wiki Article'
+
+    @classmethod
+    def copy_article_revision(kls, revision):
+        """
+        Create/Update LatestArticleRevision from an ArticleRevision instance
+        """
+        with transaction.commit_on_success():
+            latest_article, lar_created = kls.objects.get_or_create(
+                article_id=revision.article.id,
+            )
+            latest_article.title = revision.title
+            latest_article.content = revision.content
+            latest_article.save()
+
+    @classmethod
+    def purge(kls, article):
+        """
+        Remove LatestArticleRevision whose article was deleted or purged
+        """
+        kls.objects.filter(article_id=article.id).delete()
+
+    def __unicode__(self):
+        return self.title
+
+    @models.permalink
+    def get_absolute_url(self):
+        return ('wiki:get', (self.article_id,))
 
 searchable_models = load_search_model_indexes()

--- a/raspberryio/search/utils.py
+++ b/raspberryio/search/utils.py
@@ -85,6 +85,9 @@ def make_search_proxy_model(ModelKls, search_fields):
     """
 
     kls_name = 'Searchable' + ModelKls.__name__
+    search_classname = getattr(
+        ModelKls, 'search_classname', ModelKls.__name__.lower()
+    )
 
     class Meta(object):
         proxy = True
@@ -95,7 +98,7 @@ def make_search_proxy_model(ModelKls, search_fields):
 
     return type(kls_name, (Searchable, ModelKls), {
         'search_fields': search_fields,
-        'search_classname': ModelKls.__name__.lower(),
+        'search_classname': search_classname,
         'Meta': Meta,
         '__module__': ModelKls.__module__
     })

--- a/raspberryio/settings/base.py
+++ b/raspberryio/settings/base.py
@@ -294,6 +294,9 @@ SEARCH_MODEL_INDEXES = {
     'project.project': {
         'title': 10, 'tldr': 5,
     },
+    'qanda.question': {
+        'title': 10, 'question': 5,
+    },
 }
 
 ####################

--- a/raspberryio/settings/base.py
+++ b/raspberryio/settings/base.py
@@ -297,6 +297,13 @@ SEARCH_MODEL_INDEXES = {
     'qanda.question': {
         'title': 10, 'question': 5,
     },
+    'qanda.answer': {
+        'answer': 3,
+    },
+    # LatestArticleRevision represents the latest flat list of wiki articles
+    'search.latestarticlerevision': {
+        'title': 10, 'content': 5,
+    },
 }
 
 ####################

--- a/raspberryio/signals.py
+++ b/raspberryio/signals.py
@@ -1,9 +1,44 @@
-from django.db.models.signals import post_save
-from actstream import action
-from wiki.models.article import ArticleRevision
+from django.db.models.signals import post_save, pre_delete
 
-def wiki_actstream_handler(sender, instance, created, **kwargs):
+from actstream import action
+from wiki.models.article import Article, ArticleRevision
+
+from raspberryio.search.models import LatestArticleRevision
+
+
+def wiki_article_handler(sender, instance, created, **kwargs):
+    revision = instance.current_revision
+    if revision:
+        # Copy the revision, but if it is deleted remove LatestArticleRevisions
+        if not revision.deleted:
+            LatestArticleRevision.copy_article_revision(revision)
+        else:
+            LatestArticleRevision.purge(instance)
+
+
+def wiki_revision_handler(sender, instance, created, **kwargs):
+    # Add wiki article edit to user's Activity Stream
     if instance.user:
         action.send(instance.user, verb='edited the wiki article', target=instance.article)
+    # Create/Update LatestArticleRevision
+    LatestArticleRevision.copy_article_revision(instance)
 
-post_save.connect(wiki_actstream_handler, sender=ArticleRevision)
+
+def wiki_article_delete_handler(sender, instance, **kwargs):
+    # Article is purged, remove all LatestArticleRevisions if still present
+    LatestArticleRevision.purge(instance)
+
+
+def wiki_revision_delete_handler(sender, instance, **kwargs):
+    # If a revision is somehow deleted, but the article still has a current
+    # revision update LatestArtcileRevision to match that one
+    if instance.article and instance.article.current_revision:
+        LatestArticleRevision.copy_article_revision(
+            instance.article.current_revision
+        )
+
+
+post_save.connect(wiki_article_handler, sender=Article)
+post_save.connect(wiki_revision_handler, sender=ArticleRevision)
+pre_delete.connect(wiki_article_delete_handler, sender=Article)
+pre_delete.connect(wiki_article_delete_handler, sender=ArticleRevision)

--- a/raspberryio/templates/base.html
+++ b/raspberryio/templates/base.html
@@ -166,9 +166,13 @@
 
     <script src="{{ STATIC_URL }}js/libs/bootstrap.min.js"></script>
 
-    {% compress js %}
-    <script src="{{ STATIC_URL }}js/site.js"></script>
-    {% endcompress %}
+    {% if debug %}
+        <script src="{{ STATIC_URL }}js/site.js"></script>
+    {% else %}
+        {% compress js %}
+            <script src="{{ STATIC_URL }}js/site.js"></script>
+        {% endcompress %}
+    {% endif %}
 
     {% block extra_js %}{% endblock %}
     {% render_block "js" %}

--- a/raspberryio/templates/search/search_results.html
+++ b/raspberryio/templates/search/search_results.html
@@ -52,6 +52,8 @@
                         <p>{{ result.description|truncatewords_html:50|safe }}</p>
                     {% elif result.profile.bio %}
                         <p>{{ result.profile.bio|truncatewords:50 }}</p>
+                    {% elif result.content %}
+                        <p>{{ result.content|truncatewords:50 }}</p>
                     {% endif %}
                 </div>
             {% endfor %}


### PR DESCRIPTION
Refs #78

Adding Q and A models to search was uneventful, but the django-wiki models didn't provide a flat list of the current article revisions for us to search on. I added such a model and the signals required to keep it up to date with wiki changes.

I'd like to simplify this a bit if possible, but I haven't found a better solution.
