### PR TITLE
Added ability to delete project and project steps. Added cancel buttons

### DIFF
--- a/raspberryio/project/urls.py
+++ b/raspberryio/project/urls.py
@@ -28,7 +28,18 @@ urlpatterns = patterns('raspberryio.project.views',
         name='project-step-create-edit'
     ),
 
-    # Ajax views
+    # Delete project
+    url(
+        r'^delete/(?P<project_pk>[\d]+)/$', 'project_delete',
+        name='project-delete'
+    ),
+    # Delete project step
+    url(
+        r'^delete-step/(?P<project_step_pk>[\d]+)/$', 'project_step_delete',
+        name='project-step-delete'
+    ),
+
+    # --- Ajax views
 
     # Publish a project
     url(

--- a/raspberryio/project/views.py
+++ b/raspberryio/project/views.py
@@ -116,6 +116,34 @@ def project_step_create_edit(request, project_slug, project_step_number=None):
 
 
 @login_required
+def project_delete(request, project_pk):
+    user = request.user
+    project = get_object_or_404(Project, id=project_pk)
+    if not user.is_superuser and project.user != user:
+        return HttpResponseForbidden('You are not the owner of this project.')
+    if 'ok' in request.POST:
+        project.delete()
+        return redirect(request.user)
+    return render(request, 'project/project_delete.html', {
+        'project': project,
+    })
+
+
+@login_required
+def project_step_delete(request, project_step_pk):
+    user = request.user
+    project_step = get_object_or_404(ProjectStep, id=project_step_pk)
+    if not user.is_superuser and project_step.project.user != user:
+        return HttpResponseForbidden('You are not the owner of this project.')
+    if 'ok' in request.POST:
+        project_step.delete()
+        return redirect(project_step.project)
+    return render(request, 'project/project_step_delete.html', {
+        'project_step': project_step,
+    })
+
+
+@login_required
 @ajax_only
 def publish_project(request, project_slug):
     user = request.user

--- a/raspberryio/static/less/site.less
+++ b/raspberryio/static/less/site.less
@@ -804,6 +804,10 @@ body#project-detail {
 				.btn; 
 				.btn-success;
 			}
+			a.delete {
+				.btn;
+				.btn-danger;
+			}
 		}
 		.userinfo {
 			img { border: 3px solid @white; }
@@ -859,6 +863,10 @@ body#project-detail {
 				.btn;
 				.btn-success;
 			}
+			a.delete {
+				.btn;
+				.btn-danger;
+			}
 		}
 	}
 	.gallery-display {
@@ -905,6 +913,10 @@ body#project-create-edit {
 body#project-step-create-edit {
 	h2 {
 		.page-header;
+	}
+	a#cancel-step {
+		.btn;
+		.btn-success;
 	}
 	form {
 		&#fileupload {

--- a/raspberryio/templates/project/project_create_edit.html
+++ b/raspberryio/templates/project/project_create_edit.html
@@ -13,8 +13,9 @@
             {{ project_form.media }}
             <input type="submit" id="submit-project-create-edit" name="save" value="Save &amp; preview" />
                 {% if not project.id %}
-                    <input type="submit" id="submit-project-create-edit" name="save-add-step" value="Save &amp; add project steps" />
+                    <input type="submit" id="submit-project-create-edit-and-add" name="save-add-step" value="Save &amp; add project steps" />
                 {% endif %}
+            <input type="button" id="submit-project-create-edit-cancel" name="cancel" value="Cancel" onclick="history.go(-1);" />
         </form>
     </div>
 </div>

--- a/raspberryio/templates/project/project_delete.html
+++ b/raspberryio/templates/project/project_delete.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% load url from future %}
+
+{% block body_id %}project-delete{% endblock %}
+
+{% block main %}
+    <div class="row">
+        <div class="span12">
+            <h2>Delete project</h2>
+            <form class="project-delete-form" action="" method="post" accept-charset="utf-8" enctype="multipart/form-data"> {% csrf_token %}
+                Are you sure you want to delete the project "{{ project.title }}" permanently?
+                <input type="submit" id="submit-project-delete" name="ok" value="Ok" />
+                <input type="button" id="submit-project-cancel" name="cancel" value="Cancel" onclick="history.go(-1);"/>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/raspberryio/templates/project/project_detail.html
+++ b/raspberryio/templates/project/project_detail.html
@@ -28,7 +28,7 @@
                     <a href="{% url 'project-create-edit' project.slug %}"><i class="icon-edit icon-white"></i> Edit Project</a>
                     {% if project.steps.count > 20 %}
                     <a href="{% url 'project-step-create-edit' project.slug %}"><i class="icon-plus icon-white"></i> Add Step</a>
-                    {% endif %}
+                    <a href="{% url 'project-delete' project.id %}" class="btn-danger warning"><i class="icon-trash icon-white"></i> Delete Project</a>
                 {% endif %}
                 {# Leaving in here for now. This is slated for Phase II work. #}
                 {% comment %}
@@ -106,6 +106,7 @@
                 <h3>Step {{ forloop.counter }}
                     {% if request.user == project.user or request.user.is_superuser %}
                         <a href="{% url 'project-step-create-edit' project.slug step.order %}"><i class="icon-edit icon-white"></i> Edit Step</a>
+                        <a href="{% url 'project-step-delete' step.id %}"><i class="icon-trash btn-danger icon-white"></i> Delete Step</a>
                     {% endif %}
                 </h3>
                 {# FIXME: Determine the whitelist of html tags and assure this won't break the page #}

--- a/raspberryio/templates/project/project_detail.html
+++ b/raspberryio/templates/project/project_detail.html
@@ -28,7 +28,9 @@
                     <a href="{% url 'project-create-edit' project.slug %}"><i class="icon-edit icon-white"></i> Edit Project</a>
                     {% if project.steps.count > 20 %}
                     <a href="{% url 'project-step-create-edit' project.slug %}"><i class="icon-plus icon-white"></i> Add Step</a>
-                    <a class="delete" href="{% url 'project-delete' project.id %}"><i class="icon-trash icon-white"></i> Delete Project</a>
+                    {% endif %}
+
+                    <a href="{% url 'project-delete' project.id %}" class="btn-danger warning"><i class="icon-trash icon-white"></i> Delete Project</a>
                 {% endif %}
                 {# Leaving in here for now. This is slated for Phase II work. #}
                 {% comment %}
@@ -106,7 +108,7 @@
                 <h3>Step {{ forloop.counter }}
                     {% if request.user == project.user or request.user.is_superuser %}
                         <a href="{% url 'project-step-create-edit' project.slug step.order %}"><i class="icon-edit icon-white"></i> Edit Step</a>
-                        <a href="{% url 'project-step-delete' step.id %}" class="delete"><i class="icon-trash icon-white"></i> Delete Step</a>
+                        <a href="{% url 'project-step-delete' step.id %}"><i class="icon-trash btn-danger icon-white"></i> Delete Step</a>
                     {% endif %}
                 </h3>
                 {# FIXME: Determine the whitelist of html tags and assure this won't break the page #}

--- a/raspberryio/templates/project/project_detail.html
+++ b/raspberryio/templates/project/project_detail.html
@@ -28,7 +28,7 @@
                     <a href="{% url 'project-create-edit' project.slug %}"><i class="icon-edit icon-white"></i> Edit Project</a>
                     {% if project.steps.count > 20 %}
                     <a href="{% url 'project-step-create-edit' project.slug %}"><i class="icon-plus icon-white"></i> Add Step</a>
-                    <a href="{% url 'project-delete' project.id %}" class="btn-danger warning"><i class="icon-trash icon-white"></i> Delete Project</a>
+                    <a href="{% url 'project-delete' project.id %}"><i class="icon-trash icon-white"></i> Delete Project</a>
                 {% endif %}
                 {# Leaving in here for now. This is slated for Phase II work. #}
                 {% comment %}
@@ -106,7 +106,7 @@
                 <h3>Step {{ forloop.counter }}
                     {% if request.user == project.user or request.user.is_superuser %}
                         <a href="{% url 'project-step-create-edit' project.slug step.order %}"><i class="icon-edit icon-white"></i> Edit Step</a>
-                        <a href="{% url 'project-step-delete' step.id %}"><i class="icon-trash btn-danger icon-white"></i> Delete Step</a>
+                        <a href="{% url 'project-step-delete' step.id %}"><i class="icon-trash icon-white"></i> Delete Step</a>
                     {% endif %}
                 </h3>
                 {# FIXME: Determine the whitelist of html tags and assure this won't break the page #}

--- a/raspberryio/templates/project/project_detail.html
+++ b/raspberryio/templates/project/project_detail.html
@@ -28,7 +28,7 @@
                     <a href="{% url 'project-create-edit' project.slug %}"><i class="icon-edit icon-white"></i> Edit Project</a>
                     {% if project.steps.count > 20 %}
                     <a href="{% url 'project-step-create-edit' project.slug %}"><i class="icon-plus icon-white"></i> Add Step</a>
-                    <a href="{% url 'project-delete' project.id %}"><i class="icon-trash icon-white"></i> Delete Project</a>
+                    <a class="delete" href="{% url 'project-delete' project.id %}"><i class="icon-trash icon-white"></i> Delete Project</a>
                 {% endif %}
                 {# Leaving in here for now. This is slated for Phase II work. #}
                 {% comment %}
@@ -106,7 +106,7 @@
                 <h3>Step {{ forloop.counter }}
                     {% if request.user == project.user or request.user.is_superuser %}
                         <a href="{% url 'project-step-create-edit' project.slug step.order %}"><i class="icon-edit icon-white"></i> Edit Step</a>
-                        <a href="{% url 'project-step-delete' step.id %}"><i class="icon-trash icon-white"></i> Delete Step</a>
+                        <a href="{% url 'project-step-delete' step.id %}" class="delete"><i class="icon-trash icon-white"></i> Delete Step</a>
                     {% endif %}
                 </h3>
                 {# FIXME: Determine the whitelist of html tags and assure this won't break the page #}

--- a/raspberryio/templates/project/project_step_create_edit.html
+++ b/raspberryio/templates/project/project_step_create_edit.html
@@ -22,7 +22,7 @@
         {{ project_step_form.media }}
         <input type="submit" name="save" id="submit-project-step-create-edit" value="Save & view"/>
         <input type="submit" name="save-add" id="submit-project-step-create-edit-add-another" value="Save &amp; add a step" />
-        <a class="btn btn-success" href="{% url 'project-create-edit' project.slug %}" id="project-step-create-edit-cancel">Cancel</a>
+        <a id="cancel-step" href="{% url 'project-create-edit' project.slug %}" id="project-step-create-edit-cancel">Cancel</a>
     </form>
 {% endblock %}
 

--- a/raspberryio/templates/project/project_step_create_edit.html
+++ b/raspberryio/templates/project/project_step_create_edit.html
@@ -22,6 +22,7 @@
         {{ project_step_form.media }}
         <input type="submit" name="save" id="submit-project-step-create-edit" value="Save & view"/>
         <input type="submit" name="save-add" id="submit-project-step-create-edit-add-another" value="Save &amp; add a step" />
+        <a class="btn btn-success" href="{% url 'project-create-edit' project.slug %}" id="project-step-create-edit-cancel">Cancel</a>
     </form>
 {% endblock %}
 

--- a/raspberryio/templates/project/project_step_delete.html
+++ b/raspberryio/templates/project/project_step_delete.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% load url from future %}
+
+{% block body_id %}project-delete{% endblock %}
+
+{% block main %}
+    <div class="row">
+        <div class="span12">
+            <h2>Delete project step</h2>
+            <form class="project-step-delete-form" action="" method="post" accept-charset="utf-8" enctype="multipart/form-data"> {% csrf_token %}
+                Are you sure you want to delete step {{ project_step.get_order_display }} of "{{ project_step.project.title }}" permanently?
+                <input type="submit" id="submit-project-step-delete" name="ok" value="Ok" />
+                <input type="button" id="submit-project-step-cancel" name="cancel" value="Cancel" onclick="history.go(-1);"/>
+            </form>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Refs #109

Reviewers:
Consider if the redirect behavior I've programmed seems reasonable for the deletion and cancellation cases. This PR adds the ability to delete or cancel projects or project steps, so there are 4 redirects.

I think what I have currently WRT redirects makes sense, but in particular, I'm concerned about the cancellation of adding a project step and where this should redirect. Redirecting to the previous page is usually the most expected, but in this case it might redirect to a the create project step page of a step that was just added and can fool the user into accidentally creating the step twice.
