### PR TITLE
Fixes to enable SSL

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -20,7 +20,7 @@ CONF_ROOT = os.path.join(PROJECT_ROOT, 'conf')
 SERVER_ROLES = ['app', 'lb', 'db']
 env.project = 'raspberryio'
 env.project_user = 'raspberryio'
-env.repo = u'git@github.com:caktus/raspberryio.git'
+env.repo = u'git@github.com:python/raspberryio.git'
 env.shell = '/bin/bash -c'
 env.disable_known_hosts = True
 env.ssh_port = 2222
@@ -386,5 +386,3 @@ def reset_local_db():
     local('createdb %s' % local_db)
     host = '%s@%s' % (env.project_user, env.hosts[0])
     local('ssh -p %s -C %s pg_dump -Ox %s | psql %s' % (env.ssh_port, host, remote_db, local_db))
-
-

--- a/raspberryio/settings/base.py
+++ b/raspberryio/settings/base.py
@@ -121,7 +121,7 @@ MIDDLEWARE_CLASSES = (
     "mezzanine.core.middleware.AdminLoginInterfaceSelectorMiddleware",
     "mezzanine.core.middleware.SitePermissionMiddleware",
     # Uncomment the following if using any of the SSL settings:
-    # "mezzanine.core.middleware.SSLRedirectMiddleware",
+    "mezzanine.core.middleware.SSLRedirectMiddleware",
     "mezzanine.pages.middleware.PageMiddleware",
     'django.middleware.cache.FetchFromCacheMiddleware',
 )

--- a/raspberryio/settings/staging.py
+++ b/raspberryio/settings/staging.py
@@ -3,6 +3,9 @@ import os
 
 from ConfigParser import RawConfigParser
 
+# Setup Mezzanine SSL
+SSL_ENABLED = True
+
 from raspberryio.settings.base import *
 
 DEBUG = False
@@ -27,9 +30,6 @@ CACHES = {
 }
 
 EMAIL_SUBJECT_PREFIX = '[Raspberryio Staging] '
-
-# Setup Mezzanine SSL
-SSL_ENABLED = True
 
 # Django Compressor configuration
 COMPRESS_ENABLED = True

--- a/raspberryio/settings/staging.py
+++ b/raspberryio/settings/staging.py
@@ -28,6 +28,9 @@ CACHES = {
 
 EMAIL_SUBJECT_PREFIX = '[Raspberryio Staging] '
 
+# Setup Mezzanine SSL
+SSL_ENABLED = True
+
 # Django Compressor configuration
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True

--- a/raspberryio/settings/staging.py
+++ b/raspberryio/settings/staging.py
@@ -3,9 +3,6 @@ import os
 
 from ConfigParser import RawConfigParser
 
-# Setup Mezzanine SSL
-SSL_ENABLED = True
-
 from raspberryio.settings.base import *
 
 DEBUG = False
@@ -34,6 +31,10 @@ EMAIL_SUBJECT_PREFIX = '[Raspberryio Staging] '
 # Django Compressor configuration
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
+
+# Setup SSL
+SSL_ENABLED = True
+SECURE_PROXY_SSL_HEADER = ('X-Forwarded-Proto', 'https')
 
 # import secrets
 try:

--- a/raspberryio/settings/staging.py
+++ b/raspberryio/settings/staging.py
@@ -33,7 +33,6 @@ COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 
 # Setup SSL
-SSL_ENABLED = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # import secrets

--- a/raspberryio/settings/staging.py
+++ b/raspberryio/settings/staging.py
@@ -34,7 +34,7 @@ COMPRESS_OFFLINE = True
 
 # Setup SSL
 SSL_ENABLED = True
-SECURE_PROXY_SSL_HEADER = ('X-Forwarded-Proto', 'https')
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # import secrets
 try:

--- a/raspberryio/templates/base.html
+++ b/raspberryio/templates/base.html
@@ -179,7 +179,7 @@
 {% endblock %}
 </div>
 
-<script src="//code.jquery.com/jquery-1.8.3.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 {% include "includes/footer_scripts.html" %}
 <script src="{{ STATIC_URL }}js/libs/bootstrap.min.js"></script>
 


### PR DESCRIPTION
- Point to SSL version of Jquery CDN
- Enable Mezzanine SSL Middleware
- Set SSL_ENABLED to True, which will force URLS starting with
  '/account' and '/admin' to SSL

Refs #173, #140 

/cc @calebsmith 
