### PR TITLE
Remove secrets

### DIFF
--- a/raspberryio/settings/base.py
+++ b/raspberryio/settings/base.py
@@ -85,9 +85,6 @@ STATICFILES_FINDERS = (
     'compressor.finders.CompressorFinder',
 )
 
-# Make this unique, and don't share it with anybody.
-SECRET_KEY = 'yv!hkvt&amp;k8dn^$*$&amp;lif)#ydw8zvk4iz93s8m+$x%eyg-!$n69'
-
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',

--- a/raspberryio/settings/local.example.py
+++ b/raspberryio/settings/local.example.py
@@ -2,7 +2,11 @@ import sys
 
 from raspberryio.settings.dev import *
 
-# Override settings here
+## Override settings here
+
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = 'yv!hkvt&amp;k8dn^$*$&amp;lif)#ydw8zvk4iz93s8m+$x%eyg-!$n69'
+
 
 # Special test settings
 if 'test' in sys.argv:

--- a/raspberryio/settings/production.py
+++ b/raspberryio/settings/production.py
@@ -11,6 +11,7 @@ try:
     config = RawConfigParser()
     config.read(os.path.join(SECRETS_ROOT, 'settings.ini'))
     SUPERFEEDR_CREDS = json.loads(config.get('secrets', 'SUPERFEEDR_CREDS'))
+    SECRET_KEY = json.loads(config.get('secrets', 'SECRET_KEY'))
     DATABASES['default']['NAME'] = config.get('database', 'DATABASE_NAME')
     DATABASES['default']['HOST'] = config.get('database', 'DATABASE_HOST')
     DATABASES['default']['USER'] = config.get('database', 'DATABASE_USER')

--- a/raspberryio/settings/staging.py
+++ b/raspberryio/settings/staging.py
@@ -41,5 +41,6 @@ try:
     config = RawConfigParser()
     config.read(os.path.join(SECRETS_ROOT, 'settings.ini'))
     SUPERFEEDR_CREDS = json.loads(config.get('secrets', 'SUPERFEEDR_CREDS'))
+    SECRET_KEY = json.loads(config.get('secrets', 'SECRET_KEY'))
 except:
     pass

--- a/raspberryio/settings/travis.py
+++ b/raspberryio/settings/travis.py
@@ -2,7 +2,11 @@ import sys
 
 from raspberryio.settings.dev import *
 
-# Override settings here
+## Override settings here
+
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = 'yv!hkvt&amp;k8dn^$*$&amp;lif)#ydw8zvk4iz93s8m+$x%eyg-!$n69'
+
 
 # Special test settings
 if 'test' in sys.argv:


### PR DESCRIPTION
- Move SECRET_KEY from base.py to local.example.py where it can be customized
- Put a copy in travis.py so that Travis will still work
- Production and Staging already have a mechanism to pull in secrets. Add SECRET_KEY there

After this commit, I will push the secret files to staging via `fab staging upload_secrets:staging.ini` and if successful, will repeat on production

/cc @calebsmith 
