### PR TITLE
Implement Disqus comments

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -4,6 +4,7 @@ Raspberry IO Changelog
 Version 0.3 (Unreleased)
 ------------------------
 
+* Add DISQUS comments to project detail page
 * Fabfile fixes
 * Improve pagination throughout site
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -4,6 +4,7 @@ Raspberry IO Changelog
 Version 0.3 (Unreleased)
 ------------------------
 
+* Improve coverage to near 100% (excepting aggregator)
 * Add DISQUS comments to project detail page
 * Add link to RaspberryIO Twitter account
 * Improve pagination throughout site

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -88,3 +88,16 @@ this flattened representation of the latest revision in its own table,
 and should be used in the future for any other models with a similar
 structure. Using something in MPTT or similar might be better than the
 current "flatten and copy" behavior, but this is what we have for now.
+
+Comments:
+---------
+
+We use `Disqus <http://disqus.com/>`_ to allow users to comment on
+individual projects. The ``DISQUS_HOSTNAME`` (in Django settings) is
+set to ``http://raspberry.io` so that non-production sites can see the
+commenting functionality. ``DISQUS_SHORTNAME`` is set to
+``raspberryio`` for production and ``raspberryio-staging`` for the
+staging site. If local developers wish to test commenting for some
+reason, then they should create a DISQUS account, set up a new
+shortname and use that for ``DISQUS_SHORTNAME`` in
+``raspberryio.settings.base``.

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -100,4 +100,4 @@ commenting functionality. ``DISQUS_SHORTNAME`` is set to
 staging site. If local developers wish to test commenting for some
 reason, then they should create a DISQUS account, set up a new
 shortname and use that for ``DISQUS_SHORTNAME`` in
-``raspberryio.settings.base``.
+``raspberryio.settings.local``.

--- a/raspberryio/project/views.py
+++ b/raspberryio/project/views.py
@@ -5,6 +5,7 @@ from django.contrib.sites.models import Site
 from django.contrib.auth.decorators import login_required
 from django.views.generic.list_detail import object_list
 from django.core.cache import cache
+from django.conf import settings
 
 from actstream import action
 
@@ -39,6 +40,8 @@ def project_detail(request, project_slug):
         raise Http404('There is no project here')
     return render(request, 'project/project_detail.html', {
         'project': project,
+        'DISQUS_SHORTNAME': settings.DISQUS_SHORTNAME,
+        'DISQUS_HOSTNAME': settings.DISQUS_HOSTNAME,
     })
 
 

--- a/raspberryio/settings/base.py
+++ b/raspberryio/settings/base.py
@@ -346,3 +346,7 @@ except ImportError:
     pass
 else:
     set_dynamic_settings(globals())
+
+# Disqus
+DISQUS_SHORTNAME = 'raspberryio-dev'
+DISQUS_HOSTNAME = 'http://raspberry.io'

--- a/raspberryio/settings/production.py
+++ b/raspberryio/settings/production.py
@@ -21,3 +21,6 @@ except:
     pass
 
 EMAIL_SUBJECT_PREFIX = '[Raspberryio Prod] '
+
+# Disqus
+DISQUS_SHORTNAME = 'raspberryio'

--- a/raspberryio/settings/staging.py
+++ b/raspberryio/settings/staging.py
@@ -44,3 +44,6 @@ try:
     SECRET_KEY = json.loads(config.get('secrets', 'SECRET_KEY'))
 except:
     pass
+
+# Disqus
+DISQUS_SHORTNAME = 'raspberryio-staging'

--- a/raspberryio/templates/base.html
+++ b/raspberryio/templates/base.html
@@ -10,7 +10,7 @@
     <meta name="description" content="{% block meta_description %}{% endblock %}">
     {% block extra-meta %}{% endblock %}
 
-    <title>{% block meta_title %}{% endblock %} {% block site_title %}{{ settings.SITE_TITLE }}{% endblock %}</title>
+    <title>{% block meta_title %}{% endblock %} : {% block site_title %}{{ settings.SITE_TITLE }}{% endblock %}</title>
 
     <link rel="shortcut icon" href="{{ STATIC_URL }}img/favicon.ico">
     <link rel="apple-touch-icon" href="{{ STATIC_URL }}img/apple-touch-icon.png">

--- a/raspberryio/templates/project/project_detail.html
+++ b/raspberryio/templates/project/project_detail.html
@@ -3,6 +3,7 @@
 {% load url from future %}
 {% load cache %}
 
+{% block meta_title %}{{ project.title }}{% endblock %}
 {% block body_id %}project-detail{% endblock %}
 
 {% block main %}
@@ -169,6 +170,11 @@
             </div>
         </div>
     {% endfor %}
+
+    <h2>Comments</h2>
+    <div id="disqus_thread"></div>
+    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+
 {% endblock %}
 
 {% block extra_js %}
@@ -226,4 +232,17 @@
             });
         });
     </script>
+    <script type="text/javascript">
+        var disqus_shortname = '{{ DISQUS_SHORTNAME }}';
+        var disqus_identifier = '{{ project.pk }}';
+        var disqus_url = '{{ DISQUS_HOSTNAME }}{{request.path}}';
+
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 {% endblock %}


### PR DESCRIPTION
- Add ':' between meta_title and site_title in base.html template
- Add DISQUS_HOSTNAME and DISQUS_SHORTNAME to settings
- Add Disqus div and JS to project-detail page
- Document settings in Developer docs
