### PR TITLE
Improve test coverage

### DIFF
--- a/raspberryio/aggregator/tests.py
+++ b/raspberryio/aggregator/tests.py
@@ -2,8 +2,6 @@
 # https://docs.djangoproject.com/en/dev/topics/testing/#email-services
 from __future__ import absolute_import
 
-import datetime
-
 from mock import patch
 
 from django.conf import settings
@@ -12,7 +10,7 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
-
+from django.utils.timezone import now
 from django_push.subscriber.models import SubscriptionManager
 
 from .management.commands import send_pending_approval_email
@@ -60,7 +58,7 @@ class AggregatorTests(TestCase):
             for feed in [self.approved_feed, self.denied_feed, self.pending_feed, self.defunct_feed]:
                 feed.save()
                 feed_item = models.FeedItem(feed=feed, title="%s Item" % feed.title, link=feed.public_url,
-                                     date_modified=datetime.datetime.now(), guid=feed.title)
+                                     date_modified=now(), guid=feed.title)
                 feed_item.save()
 
             self.client = Client()

--- a/raspberryio/aggregator/tests.py
+++ b/raspberryio/aggregator/tests.py
@@ -15,6 +15,7 @@ from django_push.subscriber.models import SubscriptionManager
 
 from .management.commands import send_pending_approval_email
 from . import models
+from . import utils
 
 
 class MockResponse(object):
@@ -78,3 +79,17 @@ class AggregatorTests(TestCase):
         send_pending_approval_email.Command().handle_noargs()
         self.assertEqual(1, len(mail.outbox))
         self.assertEqual(mail.outbox[0].to, [self.user.email])
+
+    def test_feed_type_items(self):
+        # 4 items were created in our default feed_type in setUp
+        self.assertEqual(len(self.feed_type.items()), 4)
+
+    def test_unicode_method(self):
+        self.assertEqual(self.approved_feed.__unicode__(), 'Approved')
+
+
+class UtilsTests(TestCase):
+
+    def test_push_credentials(self):
+        settings.SUPERFEEDR_CREDS = ['testid', 'testsecret']
+        self.assertEqual(utils.push_credentials(''), ('testid', 'testsecret'))

--- a/raspberryio/project/tests/test_forms.py
+++ b/raspberryio/project/tests/test_forms.py
@@ -7,8 +7,18 @@ from raspberryio.project.forms import ProjectImageForm, ProjectStepForm
 class ProjectFormTestCase(ProjectBaseTestCase):
 
     def setUp(self):
+        self.request_factory = RequestFactory()
         self.project = self.create_project()
 
+    def test_placeholder_labels(self):
+        request = self.request_factory.get('/')
+        form = ProjectStepForm()
+        # first assert that label is shown
+        self.assertEqual(form.fields['title'].label, 'Title')
+        form.Meta.remove_labels = True
+        form = ProjectStepForm(request.GET, instance=self.project)
+        # now assert that Meta attribute removes it
+        self.assertEqual(form.fields['title'].label, '')
 
 class ProjectStepFormTestCase(ProjectBaseTestCase):
 
@@ -98,6 +108,16 @@ class ProjectStepFormTestCase(ProjectBaseTestCase):
             self.assertEqual(tuple(project_step.gallery.all()), project_images)
         else:
             self.fail('Form should be valid')
+
+    def test_bad_video_url(self):
+        post_data = {
+            'title': self.get_random_string(),
+            'content': self.get_random_string(),
+            'video': 'http://example.com/badurl',
+        }
+        request = self.request_factory.post('/', post_data)
+        form = ProjectStepForm(request.POST, instance=self.project_step)
+        self.assertFalse(form.is_valid())
 
 
 class ProjectImageFormTestCase(ProjectBaseTestCase):

--- a/raspberryio/project/tests/test_models.py
+++ b/raspberryio/project/tests/test_models.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 
 from mezzanine.utils.timezone import now
@@ -42,6 +43,15 @@ class ProjectTestCase(ProjectBaseTestCase):
     def test_default_draft(self):
         self.assertEqual(self.project.status, CONTENT_STATUS_DRAFT)
 
+    def test_video_params(self):
+        # first test that garbage input doesn't work
+        self.assertEqual(self.project.embed_url, None)
+        # now test a real video URL
+        video_id = "6BbufUp_HNs"
+        video_url = "http://www.youtube.com/watch?v=%s" % video_id
+        project = self.create_project(featured_video=video_url)
+        self.assertEqual(project.video_id, video_id)
+        self.assertEqual(project.embed_url, 'http://www.youtube.com/embed/%s?wmode=transparent' % video_id)
 
 class ProjectStepTestCase(ProjectBaseTestCase):
 
@@ -117,3 +127,21 @@ class ProjectStepTestCase(ProjectBaseTestCase):
         self.assertEqual(project1_step1._order, 1)
         self.assertEqual(project2_step0._order, 0)
         self.assertEqual(project2_step1._order, 1)
+
+    def test_absolute_url(self):
+        self.assertEqual(self.project_step.get_absolute_url(),
+                         reverse('project-detail', args=[self.project.slug]))
+
+    def test_video_params(self):
+        # first test that garbage input doesn't work
+        self.assertEqual(self.project_step.embed_url, None)
+        # now test a real video URL
+        video_id = "6BbufUp_HNs"
+        video_url = "http://www.youtube.com/watch?v=%s" % video_id
+        project_step = self.create_project_step(video=video_url)
+        self.assertEqual(project_step.video_id, video_id)
+        self.assertEqual(project_step.embed_url, 'http://www.youtube.com/embed/%s?wmode=transparent' % video_id)
+
+    def test_unicode_method(self):
+        unicode = 'Step %d of project %s' % (self.project_step._order, self.project.title)
+        self.assertEqual(self.project_step.__unicode__(), unicode)

--- a/raspberryio/qanda/tests/test_models.py
+++ b/raspberryio/qanda/tests/test_models.py
@@ -11,6 +11,13 @@ class AnswerTestCase(QandaBaseTestCase):
             question=self.question, user=self.answer_user
         )
 
+    def test_unicode_method(self):
+        title = 'My title'
+        q = self.create_question(title=title)
+        a = self.create_answer(question=q)
+        self.assertEqual(q.__unicode__(), title)
+        self.assertEqual(a.__unicode__(), title)
+
     def test_default_score(self):
         self.assertEqual(self.answer.score, 0)
 

--- a/raspberryio/qanda/tests/test_views.py
+++ b/raspberryio/qanda/tests/test_views.py
@@ -6,6 +6,19 @@ from raspberryio.qanda.tests.base import QandaBaseTestCase
 from raspberryio.qanda.models import Question, Answer
 
 
+class IndexViewTestCase(ViewTestMixin, QandaBaseTestCase):
+    url_name = 'community-index'
+
+    def setUp(self):
+        super(IndexViewTestCase, self).setUp()
+
+    def test_index_page(self):
+        question = self.create_question()
+        response = self.client.get(self.url)
+        result = response.context['questions']
+        self.assertEqual(set(result), set([question]))
+
+
 class QuestionListViewTestCase(ViewTestMixin, QandaBaseTestCase):
     url_name = 'question-list'
 

--- a/raspberryio/settings/dev.py
+++ b/raspberryio/settings/dev.py
@@ -31,7 +31,7 @@ SOUTH_TESTS_MIGRATE = True
 
 TEST_RUNNER = 'hilbert.test.CoverageRunner'
 
-DEFAULT_TEST_LABELS = ['project', 'userprofile', 'search', 'qanda']
+DEFAULT_TEST_LABELS = ['project', 'userprofile', 'search', 'qanda', 'aggregator', ]
 
 COVERAGE_MODULES = (
     'forms',

--- a/raspberryio/userprofile/tests/__init__.py
+++ b/raspberryio/userprofile/tests/__init__.py
@@ -1,2 +1,3 @@
 from raspberryio.userprofile.tests.test_models import *
 from raspberryio.userprofile.tests.test_views import *
+from raspberryio.userprofile.tests.test_forms import *

--- a/raspberryio/userprofile/tests/test_forms.py
+++ b/raspberryio/userprofile/tests/test_forms.py
@@ -1,0 +1,17 @@
+from django.core.urlresolvers import reverse
+
+from raspberryio.project.tests.base import RaspberryIOBaseTestCase
+
+
+class UserProfileFormTestCase(RaspberryIOBaseTestCase):
+    url_name = "profile_update"
+
+    def setUp(self):
+        self.user = self.create_user(data={'username': 'test', 'password': 'pwd'})
+        self.url = reverse(self.url_name)
+
+    def test_twitter_handle_on_form(self):
+        self.client.login(username=self.user.username, password='pwd')
+        response = self.client.get(self.url)
+        twitter_el = '<input type="text" placeholder="Twitter Id" name="twitter_id" id="id_twitter_id" />'
+        self.assertContains(response, twitter_el, html=True)

--- a/raspberryio/userprofile/tests/test_models.py
+++ b/raspberryio/userprofile/tests/test_models.py
@@ -8,6 +8,12 @@ class ProfileTestCase(RaspberryIOBaseTestCase):
         self.user = self.create_user()
         self.profile = self.user.get_profile()
 
+    def test_unicode_method(self):
+        self.assertEqual(self.profile.__unicode__(), self.user.username)
+
+    def test_absolute_url(self):
+        self.assertEqual(self.profile.get_absolute_url(), '/users/%s/' % self.user.username)
+
     def test_model_clean(self):
         "Ensure the twitter_id is stripped of the @ symbol during clean"
         self.profile.twitter_id = '@test'
@@ -25,4 +31,3 @@ class ProfileTestCase(RaspberryIOBaseTestCase):
                              feed_type=self.feed_type, owner=self.profile.user)
         self.approved_feed.save()
         self.assertTrue(self.profile.feed_owner)
-

--- a/raspberryio/userprofile/tests/test_views.py
+++ b/raspberryio/userprofile/tests/test_views.py
@@ -137,3 +137,21 @@ class ActivityStreamTestCase(RaspberryIOBaseTestCase):
         response = self.client.get(url)
         actions = response.context['actions']
         self.assertEqual(len(actions), 1)
+
+
+class LoginTestCase(RaspberryIOBaseTestCase):
+    url_name = 'login'
+
+    def setUp(self):
+        self.user = self.create_user(data={'username': 'test', 'password': 'right'})
+        self.url = reverse(self.url_name)
+
+    def test_login(self):
+        # try bad password first
+        response = self.client.post(self.url, {'username': 'test', 'password': 'wrong'})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Invalid')
+        # now try right password
+        response = self.client.post(self.url, {'username': 'test', 'password': 'right'})
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse('profile-dashboard'))

--- a/raspberryio/userprofile/views.py
+++ b/raspberryio/userprofile/views.py
@@ -41,8 +41,6 @@ def login(request, template="accounts/account_login.html"):
 def profile_related_list(request, username, relation):
     "Render the list of a users folllowers or who the user is following"
     profile = get_object_or_404(Profile, user__username__iexact=username)
-    if profile.user.username != username:
-        return redirect(profile, permanent=True)
     user = profile.user
 
     # get a queryset of users described by this relationship
@@ -71,8 +69,6 @@ def profile_related_list(request, username, relation):
 def profile_actions(request, username):
     "Custom renderer for user profile activity stream"
     profile = get_object_or_404(Profile, user__username__iexact=username)
-    if profile.user.username != username:
-        return redirect(profile, permanent=True)
     user = profile.user
     return render(request, "accounts/account_profile_actions.html", {
         'user': user,


### PR DESCRIPTION
- Added aggregator to the list of modules being tested
- Improve coverage to 100% in all modules except search_models (which I didn't undestand well enough) and aggregator (which I didn't get time for)

If acceptable, I think this closes #115 for now.

/cc @calebsmith 

Final result is:

```
 Unit Test Code Coverage Results
----------------------------------------------------------------------
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
raspberryio.aggregator               0      0   100%   
raspberryio.aggregator.forms        10      0   100%   
raspberryio.aggregator.models       97     45    54%   50, 55, 70-92, 109, 112, 116-152
raspberryio.aggregator.utils         3      0   100%   
raspberryio.aggregator.views        45     30    33%   15-16, 36-44, 54-67, 77-84, 94-98
raspberryio.project                  0      0   100%   
raspberryio.project.forms           68      0   100%   
raspberryio.project.models          98      0   100%   
raspberryio.project.utils           45      0   100%   
raspberryio.project.views          128      0   100%   
raspberryio.qanda                    0      0   100%   
raspberryio.qanda.forms             27      0   100%   
raspberryio.qanda.models            41      0   100%   
raspberryio.qanda.views             57      0   100%   
raspberryio.search                   0      0   100%   
raspberryio.search.models            8      0   100%   
raspberryio.search.utils            42     10    76%   44-46, 64-67, 70-72
raspberryio.search.views            33      0   100%   
raspberryio.userprofile              0      0   100%   
raspberryio.userprofile.forms        9      0   100%   
raspberryio.userprofile.models      18      0   100%   
raspberryio.userprofile.views       59      0   100%   
--------------------------------------------------------------
TOTAL                              788     85    89%   
----------------------------------------------------------------------
```
